### PR TITLE
use portable posix_openpt instead of glibc-specific getpt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_TYPE_PID_T
 
 dnl Checks for library functions.
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(select strdup getopt_long time ctime ftime getpt grantpt unlockpt ptsname)
+AC_CHECK_FUNCS(select strdup getopt_long time ctime ftime posix_openpt grantpt unlockpt ptsname)
 AC_FUNC_SELECT_ARGTYPES
 AM_CONFIG_HEADER(config.h)
 AC_OUTPUT(Makefile src/Makefile)

--- a/src/slsnif.c
+++ b/src/slsnif.c
@@ -700,12 +700,12 @@ int main(int argc, char *argv[]) {
     }
     if (!tty_data.ptyName) {
         if (tty_data.sysvpty) {
-#if defined(HAVE_GETPT) && defined(HAVE_GRANTPT) && defined(HAVE_PTSNAME) && defined(HAVE_UNLOCKPT)
+#if defined(HAVE_POSIX_OPENPT) && defined(HAVE_GRANTPT) && defined(HAVE_PTSNAME) && defined(HAVE_UNLOCKPT)
             /* use unix98 pty */
             /* temprarily disable handler for SIGCHLD */
             signal(SIGCHLD, SIG_DFL);
             /* open pty */
-            if ((tty_data.ptyfd = getpt()) < 0 ||
+            if ((tty_data.ptyfd = posix_openpt(O_RDWR)) < 0 ||
                  grantpt(tty_data.ptyfd) < 0 ||
                  unlockpt(tty_data.ptyfd) < 0 ||
                  !(tty_data.ptyName = ptsname(tty_data.ptyfd))) {


### PR DESCRIPTION
posix_openpt is supported by posix-compliant libc's (e.g. musl) and by glibc.